### PR TITLE
IGNORE files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,34 @@
+## source: https://github.com/github/gitignore/blob/master/C%2B%2B.gitignore
+
+# Prerequisites
+*.d
+
+# Compiled Object files
+*.slo
+*.lo
+*.o
+*.obj
+
+# Precompiled Headers
+*.gch
+*.pch
+
+# Compiled Dynamic libraries
+*.so
+*.dylib
+*.dll
+
+# Fortran module files
+*.mod
+*.smod
+
+# Compiled Static libraries
+*.lai
+*.la
+*.a
+*.lib
+
+# Executables
+*.exe
+*.out
+*.app

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,10 @@
 {
 	"files.associations": {
 		"iostream": "cpp"
+	},
+	"files.exclude": {
+		"objs/": true,
+		".gitignore": true,
+		".vscode": true,
 	}
 }


### PR DESCRIPTION
Prevent remainder/build files from being carried in git operation.
Hide objs directory and hidden files from vscode.