### PR TITLE
Fix .git vide

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -82,8 +82,7 @@ else
 				RESULT=$$?
 endif
 
-IS_GIT_DIRECTORY := $(shell git rev-parse --is-inside-work-tree 2>/dev/null)
-ifeq ($(IS_GIT_DIRECTORY),true)
+ifeq ($(shell git rev-parse HEAD &>/dev/null; echo $$?),0)
 	AUTHOR	:= $(shell git log --format='%aN' | sort -u | head -c -1 | sed -z 's/\n/, /g')
 	DATE	:= $(shell git log -1 --date=format:"%Y/%m/%d %T" --format="%ad")
 	HASH	:= $(shell git rev-parse --short HEAD)


### PR DESCRIPTION
Fix contre les dossiers git qui viennent d'etre initialisé.
Finalement, il ne faut pas être dans un dossier git mais dans un dossier git qui contient un HEAD. (donc au moins un commit)
L'information n'est pas nécessaire pour le reste du makefile, la variable n'a pas à être allouée.